### PR TITLE
Improve search highlighting for multiple terms

### DIFF
--- a/app/Helpers/ViewHelper.php
+++ b/app/Helpers/ViewHelper.php
@@ -2,8 +2,6 @@
 
 namespace App\Helpers;
 
-use Illuminate\Support\Str;
-
 class ViewHelper
 {
     /**
@@ -16,21 +14,32 @@ class ViewHelper
      */
     public static function highlightText(string $text, ?string $searchTerm = null): string
     {
+        $sanitizedText = e($text);
+
         // Se não houver termo de busca, retorna o texto original sem modificação.
         if (empty($searchTerm)) {
-            return $text;
+            return $sanitizedText;
         }
 
-        // Escapa caracteres especiais no termo de busca para evitar erros no Regex.
-        // O modificador 'i' torna a busca case-insensitive (não diferencia maiúsculas de minúsculas).
-        $pattern = '/' . preg_quote($searchTerm, '/') . '/i';
+        // Divide o termo de busca em palavras relevantes (ignorando espaços extras).
+        $terms = array_unique(array_filter(preg_split('/\s+/u', trim($searchTerm))));
 
-        // Substitui o termo encontrado pela mesma palavra, mas envolvida em uma tag <mark>
-        // A classe 'bg-yellow-200 rounded px-1' é do Tailwind CSS para o estilo do destaque.
-        // '\0' no regex representa a string exata que foi encontrada.
-        $highlightedText = preg_replace($pattern, '<mark class="bg-yellow-200 rounded px-1">\0</mark>', $text);
+        if (empty($terms)) {
+            return $sanitizedText;
+        }
+
+        // Monta uma expressão regular que considera todas as palavras buscadas (case insensitive).
+        $escapedTerms = array_map(fn ($term) => preg_quote($term, '/'), $terms);
+        $pattern = '/(' . implode('|', $escapedTerms) . ')/iu';
+
+        // Substitui cada ocorrência das palavras encontradas pela mesma palavra envolvida na tag <mark>.
+        $highlightedText = preg_replace_callback(
+            $pattern,
+            fn ($matches) => '<mark class="bg-yellow-200 rounded px-1">' . $matches[0] . '</mark>',
+            $sanitizedText
+        );
 
         // Retorna o texto com destaque ou o original se a substituição falhar.
-        return $highlightedText ?? $text;
+        return $highlightedText ?? $sanitizedText;
     }
 }

--- a/resources/views/materias/_materia-search-item.blade.php
+++ b/resources/views/materias/_materia-search-item.blade.php
@@ -49,15 +49,7 @@
         </a>
 
         <p class="text-gray-600 leading-relaxed mb-4">
-            {{-- Função PHP inline para HIGHLIGHT --}}
-            @php
-                $highlight = function ($text, $term) {
-                    if (!$term) return $text;
-                    $pattern = '/' . preg_quote($term, '/') . '/i';
-                    return preg_replace($pattern, '<mark class="bg-yellow-300 rounded px-1">\0</mark>', $text);
-                };
-            @endphp
-            {!! $highlight(Str::limit($materia->ementa, 150), $searchTerm) !!}
+            @highlight(Str::limit($materia->ementa, 150), $searchTerm)
         </p>
 
         <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-500">

--- a/resources/views/materias/materia-detalhe.blade.php
+++ b/resources/views/materias/materia-detalhe.blade.php
@@ -22,14 +22,7 @@
                 <h2 class="text-xl font-semibold text-gray-800 mb-3">Ementa</h2>
                 <p class="text-gray-600 leading-relaxed">
                     {{-- Lógica de destaque aplicada aqui --}}
-                    @php
-                        $highlight = function ($text, $term) {
-                            if (!$term) return $text;
-                            $pattern = '/' . preg_quote($term, '/') . '/i';
-                            return preg_replace($pattern, '<mark class="bg-yellow-200 rounded px-1 py-0.5">\0</mark>', $text);
-                        };
-                    @endphp
-                    {!! $highlight($materia->ementa, $searchTerm) !!}
+                    @highlight($materia->ementa, $searchTerm)
                 </p>
 
                 @if($materia->categorias->isNotEmpty())


### PR DESCRIPTION
## Summary
- sanitize and enhance the highlight helper to support multiple search terms
- reuse the Blade @highlight directive in the matéria search and detail views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c5f025bc832cac7d1994fd1ae5ad